### PR TITLE
Fixed isSubscribe condition to support also producers

### DIFF
--- a/src/app/shared/asyncapi.service.ts
+++ b/src/app/shared/asyncapi.service.ts
@@ -92,7 +92,7 @@ export class AsyncApiService {
     }
 
     private mapOperation(subscribe: { message: Message; bindings?: any; }, publish: { message: Message; bindings?: any; }): Operation {
-        const isSubscribe = subscribe !== null;
+        const isSubscribe = !!subscribe;
 
         if (isSubscribe) {
             return {


### PR DESCRIPTION
In the case when we have a producer, the mapOperation method is called with `mapOperation(undefined, {..}).`
As `undefined` is not `null` the condition `subscribe !== null` is always `true`.  This leads to an exception because we choose also the if path for the subscribe when subscribe is undefined (the case when have a producer).