### PR TITLE
Add optional message description for manual consumer/producer definition

### DIFF
--- a/src/app/channels/channel-main/channel-main.component.html
+++ b/src/app/channels/channel-main/channel-main.component.html
@@ -1,5 +1,9 @@
 <section>
     <mat-divider></mat-divider>
+    <div *ngIf="operation.message.description">
+      <h4>{{ operation.message.description }}</h4>
+      <mat-divider></mat-divider>
+    </div>
     <mat-tab-group animationDuration="0ms">
       <mat-tab label="Example">
         <div fxLayout="column">

--- a/src/app/shared/mock.json
+++ b/src/app/shared/mock.json
@@ -28,6 +28,7 @@
           "message": {
             "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "title": "AnotherPayloadDto",
+            "description": "Custom, optional description for this message",
             "payload": {
               "$ref": "#/components/schemas/AnotherPayloadDto"
             }
@@ -58,6 +59,7 @@
               {
                 "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
                 "title": "ExamplePayloadDto",
+                "description": "Custom, optional description for this message",
                 "payload": {
                   "$ref": "#/components/schemas/ExamplePayloadDto"
                 }

--- a/src/app/shared/models/channel.model.ts
+++ b/src/app/shared/models/channel.model.ts
@@ -13,5 +13,6 @@ export interface Operation {
 export interface Message {
     name: string;
     title: string;
+    description?: string;
     payload: { $ref: string };
 }


### PR DESCRIPTION
UI changes related to https://github.com/springwolf/springwolf-core/pull/84

The description is only shown if a description is provided. Otherwise the current view is kept.

Preview:
![image](https://user-images.githubusercontent.com/7568775/184509199-88030a2b-ff13-4178-85f9-225c53c9d609.png)
