### PR TITLE
feat: Add download link for async api doc

### DIFF
--- a/src/app/info/info.component.html
+++ b/src/app/info/info.component.html
@@ -1,3 +1,7 @@
 <h1>{{ info?.title }}</h1>
-<h5>API VERSION {{ info?.version }}</h5>
+<h5>
+  API VERSION {{ info?.version }}
+  -
+  <a href="#" (click)="download()">AsyncAPI JSON file</a>
+</h5>
 <p *ngIf="info?.description">{{ info.description }}</p>

--- a/src/app/info/info.component.ts
+++ b/src/app/info/info.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { AsyncApi } from '../shared/models/asyncapi.model';
 import { Info } from '../shared/models/info.model';
 import { AsyncApiService } from '../shared/asyncapi.service';
 import { Subscription } from 'rxjs';
@@ -10,6 +11,7 @@ import { Subscription } from 'rxjs';
 })
 export class InfoComponent implements OnInit {
 
+  asyncApiData: AsyncApi;
   info: Info;
   nameSubscription: Subscription;
 
@@ -17,8 +19,21 @@ export class InfoComponent implements OnInit {
 
   ngOnInit(): void {
     this.nameSubscription = this.asyncApiService.getCurrentAsyncApiName().subscribe(name => {
-      this.asyncApiService.getAsyncApis().subscribe(asyncapi => this.info = asyncapi.get(name).info);
+      this.asyncApiService.getAsyncApis().subscribe(asyncapi => {
+        this.asyncApiData = asyncapi.get(name);
+        this.info = asyncapi.get(name).info;
+      });
     });
+  }
+
+  async download(): Promise<Boolean> {
+    var json = JSON.stringify(this.asyncApiData, null, 2);
+    var bytes = new TextEncoder().encode(json);
+    var blob = new Blob([bytes], { type: 'application/json' });
+    var url = window.URL.createObjectURL(blob);
+    window.open(url);
+
+    return false;
   }
 
 }


### PR DESCRIPTION
Add a download link for the selected asyncApi definition.
Since the /docs site can contain multiple asyncApi docs, the selected definition is extracted and downloaded via an own `Blob`.

Preview: https://deploy-preview-3--timonback-springwolf-ui.netlify.app/asyncapi-ui.html

Closes https://github.com/springwolf/springwolf-ui/issues/6