### PR TITLE
Remove multiple documents support

### DIFF
--- a/src/app/channels/channel-main/channel-main.component.ts
+++ b/src/app/channels/channel-main/channel-main.component.ts
@@ -5,7 +5,6 @@ import { Schema } from 'src/app/shared/models/schema.model';
 import { PublisherService } from 'src/app/shared/publisher.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Operation } from 'src/app/shared/models/channel.model';
-import { Subscription } from 'rxjs';
 import { STATUS } from 'angular-in-memory-web-api';
 
 @Component({
@@ -39,7 +38,7 @@ export class ChannelMainComponent implements OnInit {
   ngOnInit(): void {
     this.asyncApiService.getAsyncApis().subscribe(
       asyncapi => {
-        let schemas: Map<string, Schema> = asyncapi.get(this.docName).components.schemas;
+        let schemas: Map<string, Schema> = asyncapi.components.schemas;
         this.schemaName = this.operation.message.payload.$ref.slice(this.operation.message.payload.$ref.lastIndexOf('/') + 1)
         this.schema = schemas[this.schemaName];
 

--- a/src/app/channels/channels.component.ts
+++ b/src/app/channels/channels.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { AsyncApiService } from '../shared/asyncapi.service';
 import { Channel } from '../shared/models/channel.model';
-import { subscribeOn } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
-import {Location} from "@angular/common";
+import { Location } from "@angular/common";
 
 @Component({
   selector: 'app-channels',
@@ -15,7 +13,6 @@ export class ChannelsComponent implements OnInit {
 
   channels: Channel[];
   selectedChannel: string;
-  nameSubscription: Subscription;
   docName: string;
 
   constructor(private asyncApiService: AsyncApiService, private location: Location) {
@@ -23,23 +20,20 @@ export class ChannelsComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.location.subscribe(() : void => this.setChannelSelectionFromLocation())
+    this.location.subscribe((): void => this.setChannelSelectionFromLocation())
 
-    this.nameSubscription = this.asyncApiService.getCurrentAsyncApiName().subscribe(name => {
-      this.docName = name;
-      this.asyncApiService.getAsyncApis().subscribe(asyncapi => {
-        this.channels = this.sortChannels(asyncapi.get(name).channels);
-      });
+    this.asyncApiService.getAsyncApis().subscribe(asyncapi => {
+      this.channels = this.sortChannels(asyncapi.channels);
     });
   }
 
   private sortChannels(channels: Array<Channel>): Array<Channel> {
-    return channels.sort((a,b) => {
-      if(a?.operation?.protocol === b?.operation?.protocol) {
-        if(a?.operation?.operation === b?.operation.operation) {
+    return channels.sort((a, b) => {
+      if (a?.operation?.protocol === b?.operation?.protocol) {
+        if (a?.operation?.operation === b?.operation.operation) {
           return a.name?.localeCompare(b.name);
         } else {
-          return a?.operation?.operation?.localeCompare(b?.operation?.operation); 
+          return a?.operation?.operation?.localeCompare(b?.operation?.operation);
         }
       } else {
         return a?.operation?.protocol?.localeCompare(b?.operation?.protocol);
@@ -52,7 +46,7 @@ export class ChannelsComponent implements OnInit {
   }
   setChannelSelectionFromLocation(): void {
     const anchor = window.location.hash.substr(1);
-    if(anchor.startsWith(ChannelsComponent.CHANNEL_ANCHOR_PREFIX)) {
+    if (anchor.startsWith(ChannelsComponent.CHANNEL_ANCHOR_PREFIX)) {
       this.selectedChannel = anchor;
     }
   }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,11 +1,5 @@
 <mat-toolbar color="primary" fxLayout fxLayoutAlign="space-between center">
-    <div fxLayout fxLayoutAlign="center center" fxLayoutGap="16px">
-        <h2>springwolf</h2>
-        <select [(ngModel)]="selectedDocumentMod">
-            <option disabled>Choose a doc</option>
-            <option *ngFor="let doc of documents" [ngValue]="doc">{{ doc }}</option>
-        </select>
-    </div>
+    <h2>springwolf</h2>
     <a href="https://github.com/stavshamir/springwolf">
         <i class="fa fa-github fa-2x"></i>
     </a>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,41 +1,9 @@
-import { Component, OnInit } from '@angular/core';
-import { AsyncApiService } from 'src/app/shared/asyncapi.service';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })
-export class HeaderComponent implements OnInit {
-  private static URL_SEARCH_DOCUMENT_PARAM = "document"
-
-  documents: string[];
-  selectedDocument: string;
-  location: Location;
-
-  constructor(private asyncApiService: AsyncApiService) {
-    this.location = window.location
-    this.selectedDocument = new URLSearchParams(window.location.search).get(HeaderComponent.URL_SEARCH_DOCUMENT_PARAM)
-  }
-
-  ngOnInit(): void {
-    this.asyncApiService.getAsyncApis().subscribe(docsMap => {
-      this.documents = [...docsMap.keys()];
-      if(!this.documents.includes(this.selectedDocument)) {
-        this.selectedDocument = this.documents[0]
-      }
-      this.asyncApiService.setCurrentAsyncApiName(this.selectedDocument);
-    });
-  }
-
-  get selectedDocumentMod() {
-    return this.selectedDocument;
-  }
-
-  set selectedDocumentMod(value) {
-    let updatedSearchParams = new URLSearchParams(window.location.search)
-    updatedSearchParams.set(HeaderComponent.URL_SEARCH_DOCUMENT_PARAM, value)
-    this.location.search = updatedSearchParams.toString()
-  }
-
+export class HeaderComponent {
 }

--- a/src/app/info/info.component.ts
+++ b/src/app/info/info.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { AsyncApi } from '../shared/models/asyncapi.model';
 import { Info } from '../shared/models/info.model';
 import { AsyncApiService } from '../shared/asyncapi.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-info',
@@ -13,16 +12,13 @@ export class InfoComponent implements OnInit {
 
   asyncApiData: AsyncApi;
   info: Info;
-  nameSubscription: Subscription;
 
   constructor(private asyncApiService: AsyncApiService) { }
 
   ngOnInit(): void {
-    this.nameSubscription = this.asyncApiService.getCurrentAsyncApiName().subscribe(name => {
-      this.asyncApiService.getAsyncApis().subscribe(asyncapi => {
-        this.asyncApiData = asyncapi.get(name);
-        this.info = asyncapi.get(name).info;
-      });
+    this.asyncApiService.getAsyncApis().subscribe(asyncapi => {
+      this.asyncApiData = asyncapi;
+      this.info = asyncapi.info;
     });
   }
 

--- a/src/app/schemas/schemas.component.ts
+++ b/src/app/schemas/schemas.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
-import { Subscription, SubscriptionLike } from 'rxjs';
 import { AsyncApiService } from '../shared/asyncapi.service';
 import { Schema } from '../shared/models/schema.model';
 
@@ -14,7 +13,6 @@ export class SchemasComponent implements OnInit {
 
   schemas: Map<string, Schema>;
   selectedSchema: string;
-  nameSubscription: Subscription;
 
   constructor(private asyncApiService: AsyncApiService, private location: Location) {
     this.setSchemaSelectionFromLocation()
@@ -22,10 +20,7 @@ export class SchemasComponent implements OnInit {
 
   ngOnInit(): void {
     this.location.subscribe(() : void => this.setSchemaSelectionFromLocation())
-
-    this.nameSubscription = this.asyncApiService.getCurrentAsyncApiName().subscribe(name => {
-      this.asyncApiService.getAsyncApis().subscribe(asyncapi => this.schemas = asyncapi.get(name).components.schemas);
-    });
+      this.asyncApiService.getAsyncApis().subscribe(asyncapi => this.schemas = asyncapi.components.schemas);
   }
 
   setSchemaSelection(schema: string): void {

--- a/src/app/servers/servers.component.ts
+++ b/src/app/servers/servers.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { forkJoin, Subscription, zip } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
 import { AsyncApiService } from '../shared/asyncapi.service';
 import { Server } from '../shared/models/server.model';
 
@@ -12,14 +10,11 @@ import { Server } from '../shared/models/server.model';
 export class ServersComponent implements OnInit {
 
   servers: Map<String, Server>;
-  nameSubscription: Subscription;
 
   constructor(private asyncApiService: AsyncApiService) { }
 
   ngOnInit(): void {
-    this.nameSubscription = this.asyncApiService.getCurrentAsyncApiName().subscribe(name => {
-      this.asyncApiService.getAsyncApis().subscribe(asyncapi => this.servers = asyncapi.get(name).servers );
-    });
+      this.asyncApiService.getAsyncApis().subscribe(asyncapi => this.servers = asyncapi.servers );
   }
 
 }

--- a/src/app/shared/mock/mock-server.ts
+++ b/src/app/shared/mock/mock-server.ts
@@ -20,7 +20,7 @@ export class MockServer implements InMemoryDbService {
       return reqInfo.utils.createResponse$(() => {
         return {
           status: STATUS.OK,
-          body: mockAsyncApi
+          body: mockSpringwolfKafka
         }
       });
     }

--- a/src/app/shared/mock/mock.springwolf-amqp-example.json
+++ b/src/app/shared/mock/mock.springwolf-amqp-example.json
@@ -1,310 +1,308 @@
 {
-  "Springwolf example project - AMQP": {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "Springwolf example project - AMQP",
-      "version": "1.0.0"
-    },
-    "servers": {
-      "amqp": {
-        "url": "amqp:5672",
-        "protocol": "amqp"
-      }
-    },
-    "channels": {
-      "example-bindings-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "name",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                ""
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Springwolf example project - AMQP",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "amqp": {
+      "url": "amqp:5672",
+      "protocol": "amqp"
+    }
+  },
+  "channels": {
+    "example-bindings-queue": {
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "name",
+            "autoDelete": false
           }
         }
       },
-      "example-topic-queue": {
+      "publish": {
         "bindings": {
           "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-topic-exchange",
-              "autoDelete": false
-            }
+            "cc": [
+              ""
+            ],
+            "expiration": 0,
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
           }
         },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-topic-routing-key"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
           },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        }
-      },
-      "another-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "another-queue"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        }
-      },
-      "example-manual-consumer-channel": {
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "expiration": 0,
-              "cc": [
-                "example-consumer-topic-routing-key"
-              ],
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "description": "example-manual-consumer-channel-description",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        },
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-consumer-topic-exchange",
-              "autoDelete": false
-            }
-          }
-        }
-      },
-      "example-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-queue"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        }
-      },
-      "example-producer-channel": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-topic-exchange",
-              "autoDelete": false
-            }
-          }
-        },
-        "subscribe": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-topic-routing-key"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "description": "example-producer-channel-description",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "AnotherPayloadDto": {
-          "required": [
-            "example"
-          ],
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string",
-              "description": "Foo field",
-              "example": "bar",
-              "exampleSetFlag": true
-            },
-            "example": {
-              "$ref": "#/components/schemas/ExamplePayloadDto",
-              "exampleSetFlag": false
-            }
+    "example-topic-queue": {
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "example-topic-exchange",
+            "autoDelete": false
+          }
+        }
+      },
+      "publish": {
+        "bindings": {
+          "amqp": {
+            "cc": [
+              "example-topic-routing-key"
+            ],
+            "expiration": 0,
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
           },
-          "description": "Another payload model",
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      }
+    },
+    "another-queue": {
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "",
+            "autoDelete": false
+          }
+        }
+      },
+      "publish": {
+        "bindings": {
+          "amqp": {
+            "cc": [
+              "another-queue"
+            ],
+            "expiration": 0,
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      }
+    },
+    "example-manual-consumer-channel": {
+      "publish": {
+        "bindings": {
+          "amqp": {
+            "expiration": 0,
+            "cc": [
+              "example-consumer-topic-routing-key"
+            ],
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "description": "example-manual-consumer-channel-description",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      },
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "example-consumer-topic-exchange",
+            "autoDelete": false
+          }
+        }
+      }
+    },
+    "example-queue": {
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "",
+            "autoDelete": false
+          }
+        }
+      },
+      "publish": {
+        "bindings": {
+          "amqp": {
+            "cc": [
+              "example-queue"
+            ],
+            "expiration": 0,
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      }
+    },
+    "example-producer-channel": {
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "example-topic-exchange",
+            "autoDelete": false
+          }
+        }
+      },
+      "subscribe": {
+        "bindings": {
+          "amqp": {
+            "cc": [
+              "example-topic-routing-key"
+            ],
+            "expiration": 0,
+            "priority": 0,
+            "deliveryMode": 0,
+            "mandatory": false,
+            "timestamp": false,
+            "ack": false
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "description": "example-producer-channel-description",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnotherPayloadDto": {
+        "required": [
+          "example"
+        ],
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string",
+            "description": "Foo field",
+            "example": "bar",
+            "exampleSetFlag": true
+          },
           "example": {
-            "foo": "bar",
-            "example": {
-              "someString": "some string value",
-              "someLong": 5,
-              "someEnum": "FOO2"
-            }
-          },
-          "exampleSetFlag": true
+            "$ref": "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag": false
+          }
         },
-        "ExamplePayloadDto": {
-          "required": [
-            "someEnum",
-            "someString"
-          ],
-          "type": "object",
-          "properties": {
-            "someString": {
-              "type": "string",
-              "description": "Some string field",
-              "example": "some string value",
-              "exampleSetFlag": true
-            },
-            "someLong": {
-              "type": "integer",
-              "description": "Some long field",
-              "format": "int64",
-              "example": 5,
-              "exampleSetFlag": true
-            },
-            "someEnum": {
-              "type": "string",
-              "description": "Some enum field",
-              "example": "FOO2",
-              "exampleSetFlag": true,
-              "enum": [
-                "FOO1",
-                "FOO2",
-                "FOO3"
-              ]
-            }
-          },
-          "description": "Example payload model",
+        "description": "Another payload model",
+        "example": {
+          "foo": "bar",
           "example": {
             "someString": "some string value",
             "someLong": 5,
             "someEnum": "FOO2"
-          },
-          "exampleSetFlag": true
+          }
         },
-        "NoHeaders": {
-          "type": "object",
-          "exampleSetFlag": true
-        }
+        "exampleSetFlag": true
+      },
+      "ExamplePayloadDto": {
+        "required": [
+          "someEnum",
+          "someString"
+        ],
+        "type": "object",
+        "properties": {
+          "someString": {
+            "type": "string",
+            "description": "Some string field",
+            "example": "some string value",
+            "exampleSetFlag": true
+          },
+          "someLong": {
+            "type": "integer",
+            "description": "Some long field",
+            "format": "int64",
+            "example": 5,
+            "exampleSetFlag": true
+          },
+          "someEnum": {
+            "type": "string",
+            "description": "Some enum field",
+            "example": "FOO2",
+            "exampleSetFlag": true,
+            "enum": [
+              "FOO1",
+              "FOO2",
+              "FOO3"
+            ]
+          }
+        },
+        "description": "Example payload model",
+        "example": {
+          "someString": "some string value",
+          "someLong": 5,
+          "someEnum": "FOO2"
+        },
+        "exampleSetFlag": true
+      },
+      "NoHeaders": {
+        "type": "object",
+        "exampleSetFlag": true
       }
     }
   }

--- a/src/app/shared/mock/mock.springwolf-app.json
+++ b/src/app/shared/mock/mock.springwolf-app.json
@@ -1,192 +1,196 @@
 {
-  "Springwolf UI Demo": {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "Springwolf UI Demo",
-      "description": "This is a demo project for springwolf that shows how the UI looks like and functions.",
-      "version": "1.0.0"
-    },
-    "servers": {
-      "kafka": {
-        "url": "kafka:29092",
-        "protocol": "kafka"
-      }
-    },
-    "channels": {
-      "example-consumer-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {
-              "groupId": {
-                "type": "string",
-                "enum": [
-                  "example-group-id"
-                ]
-              }
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "description": "Custom, optional description for this message",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        }
-      },
-      "example-producer-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {
-              "groupId": {
-                "type": "string",
-                "enum": [
-                  "example-group-id"
-                ]
-              }
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Springwolf UI Demo",
+    "description": "This is a demo project for springwolf that shows how the UI looks like and functions.",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "kafka": {
+      "url": "kafka:29092",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "example-consumer-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {
+            "groupId": {
+              "type": "string",
+              "enum": [
+                "example-group-id"
+              ]
             }
           }
         },
-        "subscribe": {
-          "bindings": {
-            "kafka": {}
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "description": "Custom, optional description for this message",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
           },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/NoHeaders"
-            }
-          }
-        }
-      },
-      "multi-payload-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "message": {
-            "oneOf": [
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "title": "ExamplePayloadDto",
-                "description": "Custom, optional description for this message",
-                "payload": {
-                  "$ref": "#/components/schemas/ExamplePayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/SpringDefaultHeaders"
-                }
-              },
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                "title": "AnotherPayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/AnotherPayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/NoHeaders"
-                }
-              }
-            ]
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "ExamplePayloadDto": {
-          "description": "Example payload model",
-          "type": "object",
-          "properties": {
-            "someString": {
-              "description": "some string field",
+    "example-producer-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {
+            "groupId": {
               "type": "string",
-              "example": "string"
-            },
-            "someLong": {
-              "description": "some long field",
-              "type": "integer",
-              "format": "int64",
-              "example": 0
-            },
-            "someEnum": {
-              "description": "some enum field",
-              "type": "string",
-              "enum": ["FOO1", "FOO2", "FOO3"],
-              "example": "FOO1"
+              "enum": [
+                "example-group-id"
+              ]
             }
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/ExamplePayloadDto"
           },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      },
+      "subscribe": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/NoHeaders"
+          }
+        }
+      }
+    },
+    "multi-payload-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "oneOf": [
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+              "title": "ExamplePayloadDto",
+              "description": "Custom, optional description for this message",
+              "payload": {
+                "$ref": "#/components/schemas/ExamplePayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/SpringDefaultHeaders"
+              }
+            },
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+              "title": "AnotherPayloadDto",
+              "payload": {
+                "$ref": "#/components/schemas/AnotherPayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/NoHeaders"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ExamplePayloadDto": {
+        "description": "Example payload model",
+        "type": "object",
+        "properties": {
+          "someString": {
+            "description": "some string field",
+            "type": "string",
+            "example": "string"
+          },
+          "someLong": {
+            "description": "some long field",
+            "type": "integer",
+            "format": "int64",
+            "example": 0
+          },
+          "someEnum": {
+            "description": "some enum field",
+            "type": "string",
+            "enum": [
+              "FOO1",
+              "FOO2",
+              "FOO3"
+            ],
+            "example": "FOO1"
+          }
+        },
+        "example": {
+          "someString": "string",
+          "someLong": 0,
+          "someEnum": "FOO1"
+        },
+        "required": [
+          "someString",
+          "someEnum"
+        ]
+      },
+      "AnotherPayloadDto": {
+        "description": "Another payload model",
+        "type": "object",
+        "properties": {
+          "foo": {
+            "description": "foo field",
+            "type": "string"
+          },
+          "example": {
+            "description": "example field",
+            "$ref": "#/components/schemas/ExamplePayloadDto"
+          }
+        },
+        "example": {
+          "foo": "string",
           "example": {
             "someString": "string",
             "someLong": 0,
             "someEnum": "FOO1"
-          },
-          "required": ["someString", "someEnum"]
-        },
-        "AnotherPayloadDto": {
-          "description": "Another payload model",
-          "type": "object",
-          "properties": {
-            "foo": {
-              "description": "foo field",
-              "type": "string"
-            },
-            "example": {
-              "description": "example field",
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            }
-          },
-          "example": {
-            "foo": "string",
-            "example": {
-              "someString": "string",
-              "someLong": 0,
-              "someEnum": "FOO1"
-            }
+          }
+        }
+      },
+      "NoHeaders": {
+        "type": "object",
+        "exampleSetFlag": true
+      },
+      "SpringDefaultHeaders": {
+        "type": "object",
+        "properties": {
+          "__TypeId__": {
+            "type": "string",
+            "example": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+            "exampleSetFlag": true,
+            "enum": [
+              "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+              "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
+            ]
           }
         },
-        "NoHeaders": {
-          "type": "object",
-          "exampleSetFlag": true
+        "example": {
+          "__TypeId__": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
         },
-        "SpringDefaultHeaders": {
-          "type": "object",
-          "properties": {
-            "__TypeId__": {
-              "type": "string",
-              "example": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-              "exampleSetFlag": true,
-              "enum": [
-                "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-              ]
-            }
-          },
-          "example": {
-            "__TypeId__": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-          },
-          "exampleSetFlag": true
-        }
+        "exampleSetFlag": true
       }
     }
   }
 }
-

--- a/src/app/shared/mock/mock.springwolf-kafka-example.json
+++ b/src/app/shared/mock/mock.springwolf-kafka-example.json
@@ -1,313 +1,312 @@
 {
-  "Springwolf example project - Kafka": {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "Springwolf example project - Kafka",
-      "version": "1.0.0"
-    },
-    "servers": {
-      "kafka": {
-        "url": "kafka:29092",
-        "protocol": "kafka"
-      }
-    },
-    "channels": {
-      "another-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {
-              "groupId": {
-                "type": "string",
-                "enum": [
-                  "example-group-id"
-                ]
-              }
-            }
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersUnknown"
-            }
-          }
-        },
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Springwolf example project - Kafka",
+    "description": "This is a demo project for springwolf that shows how the UI looks like and functions.",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "kafka": {
+      "url": "kafka:29092",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "another-topic": {
+      "publish": {
         "bindings": {
-          "kafka": {}
-        }
-      },
-      "example-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersUnknown"
-            }
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "example-producer-topic": {
-        "subscribe": {
-          "bindings": {
-            "kafka": {}
-          },
-          "message": {
-            "oneOf": [
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "title": "ExamplePayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/ExamplePayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/SpringDefaultHeaders"
-                }
-              },
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                "title": "AnotherPayloadDto",
-                "description": "Custom, optional description for this produced to topic",
-                "payload": {
-                  "$ref": "#/components/schemas/AnotherPayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/CloudEventHeadersForAnotherPayloadDtoEndpoint"
-                }
-              }
-            ]
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "example-consumer-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "description": "Custom, optional description for this consumed topic",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersUnknown"
-            }
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "multi-payload-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "message": {
-            "oneOf": [
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "title": "ExamplePayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/ExamplePayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersUnknown"
-                }
-              },
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                "title": "AnotherPayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/AnotherPayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersUnknown"
-                }
-              },
-              {
-                "name": "javax.money.MonetaryAmount",
-                "title": "MonetaryAmount",
-                "payload": {
-                  "$ref": "#/components/schemas/MonetaryAmount"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersUnknown"
-                }
-              }
-            ]
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      }
-    },
-    "components": {
-      "schemas": {
-        "MonetaryAmount": {
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "example": 99.99,
-              "exampleSetFlag": true
-            },
-            "currency": {
+          "kafka": {
+            "groupId": {
               "type": "string",
-              "example": "USD",
-              "exampleSetFlag": true
-            }
-          },
-          "example": {
-            "amount": 99.99,
-            "currency": "USD"
-          },
-          "exampleSetFlag": true
-        },
-        "ExamplePayloadDto": {
-          "type": "object",
-          "properties": {
-            "someString": {
-              "type": "string",
-              "exampleSetFlag": false
-            },
-            "someLong": {
-              "type": "integer",
-              "format": "int64",
-              "exampleSetFlag": false
-            },
-            "someEnum": {
-              "type": "string",
-              "exampleSetFlag": false,
               "enum": [
-                "FOO1",
-                "FOO2",
-                "FOO3"
+                "example-group-id"
               ]
             }
+          }
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
           },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersUnknown"
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "example-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersUnknown"
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "example-producer-topic": {
+      "subscribe": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "oneOf": [
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+              "title": "ExamplePayloadDto",
+              "payload": {
+                "$ref": "#/components/schemas/ExamplePayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/SpringDefaultHeaders"
+              }
+            },
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+              "title": "AnotherPayloadDto",
+              "description": "Custom, optional description for this produced to topic",
+              "payload": {
+                "$ref": "#/components/schemas/AnotherPayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/CloudEventHeadersForAnotherPayloadDtoEndpoint"
+              }
+            }
+          ]
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "example-consumer-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "description": "Custom, optional description for this consumed topic",
+          "payload": {
+            "$ref": "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersUnknown"
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "multi-payload-topic": {
+      "publish": {
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "oneOf": [
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+              "title": "ExamplePayloadDto",
+              "payload": {
+                "$ref": "#/components/schemas/ExamplePayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/HeadersUnknown"
+              }
+            },
+            {
+              "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+              "title": "AnotherPayloadDto",
+              "payload": {
+                "$ref": "#/components/schemas/AnotherPayloadDto"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/HeadersUnknown"
+              }
+            },
+            {
+              "name": "javax.money.MonetaryAmount",
+              "title": "MonetaryAmount",
+              "payload": {
+                "$ref": "#/components/schemas/MonetaryAmount"
+              },
+              "headers": {
+                "$ref": "#/components/schemas/HeadersUnknown"
+              }
+            }
+          ]
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MonetaryAmount": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "example": 99.99,
+            "exampleSetFlag": true
+          },
+          "currency": {
+            "type": "string",
+            "example": "USD",
+            "exampleSetFlag": true
+          }
+        },
+        "example": {
+          "amount": 99.99,
+          "currency": "USD"
+        },
+        "exampleSetFlag": true
+      },
+      "ExamplePayloadDto": {
+        "type": "object",
+        "properties": {
+          "someString": {
+            "type": "string",
+            "exampleSetFlag": false
+          },
+          "someLong": {
+            "type": "integer",
+            "format": "int64",
+            "exampleSetFlag": false
+          },
+          "someEnum": {
+            "type": "string",
+            "exampleSetFlag": false,
+            "enum": [
+              "FOO1",
+              "FOO2",
+              "FOO3"
+            ]
+          }
+        },
+        "example": {
+          "someString": "string",
+          "someLong": 0,
+          "someEnum": "FOO1"
+        },
+        "exampleSetFlag": true
+      },
+      "CloudEventHeadersForAnotherPayloadDtoEndpoint": {
+        "type": "object",
+        "properties": {
+          "ce_specversion": {
+            "type": "string",
+            "description": "Spec Version Header",
+            "example": "1.0",
+            "exampleSetFlag": true
+          },
+          "ce_time": {
+            "type": "string",
+            "description": "Time Header",
+            "example": "2015-07-20T15:49:04-07:00",
+            "exampleSetFlag": true
+          },
+          "content-type": {
+            "type": "string",
+            "description": "Content-Type Header",
+            "example": "application/json",
+            "exampleSetFlag": true
+          },
+          "ce_id": {
+            "type": "string",
+            "description": "Id Header",
+            "example": "1234-1234-1234",
+            "exampleSetFlag": true
+          },
+          "ce_type": {
+            "type": "string",
+            "description": "Payload Type Header",
+            "example": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
+            "exampleSetFlag": true
+          },
+          "ce_source": {
+            "type": "string",
+            "description": "Source Header",
+            "example": "springwolf-kafka-example/anotherPayloadDtoEndpoint",
+            "exampleSetFlag": true
+          }
+        },
+        "example": {
+          "ce_specversion": "1.0",
+          "ce_time": "2015-07-20T15:49:04-07:00",
+          "content-type": "application/json",
+          "ce_id": "1234-1234-1234",
+          "ce_type": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
+          "ce_source": "springwolf-kafka-example/anotherPayloadDtoEndpoint"
+        },
+        "exampleSetFlag": true
+      },
+      "HeadersUnknown": {
+        "type": "object",
+        "properties": {},
+        "example": {},
+        "exampleSetFlag": true
+      },
+      "AnotherPayloadDto": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string",
+            "exampleSetFlag": false
+          },
+          "example": {
+            "$ref": "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag": false
+          }
+        },
+        "example": {
+          "foo": "string",
           "example": {
             "someString": "string",
             "someLong": 0,
             "someEnum": "FOO1"
-          },
-          "exampleSetFlag": true
+          }
         },
-        "CloudEventHeadersForAnotherPayloadDtoEndpoint": {
-          "type": "object",
-          "properties": {
-            "ce_specversion": {
-              "type": "string",
-              "description": "Spec Version Header",
-              "example": "1.0",
-              "exampleSetFlag": true
-            },
-            "ce_time": {
-              "type": "string",
-              "description": "Time Header",
-              "example": "2015-07-20T15:49:04-07:00",
-              "exampleSetFlag": true
-            },
-            "content-type": {
-              "type": "string",
-              "description": "Content-Type Header",
-              "example": "application/json",
-              "exampleSetFlag": true
-            },
-            "ce_id": {
-              "type": "string",
-              "description": "Id Header",
-              "example": "1234-1234-1234",
-              "exampleSetFlag": true
-            },
-            "ce_type": {
-              "type": "string",
-              "description": "Payload Type Header",
-              "example": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
-              "exampleSetFlag": true
-            },
-            "ce_source": {
-              "type": "string",
-              "description": "Source Header",
-              "example": "springwolf-kafka-example/anotherPayloadDtoEndpoint",
-              "exampleSetFlag": true
-            }
-          },
-          "example": {
-            "ce_specversion": "1.0",
-            "ce_time": "2015-07-20T15:49:04-07:00",
-            "content-type": "application/json",
-            "ce_id": "1234-1234-1234",
-            "ce_type": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
-            "ce_source": "springwolf-kafka-example/anotherPayloadDtoEndpoint"
-          },
-          "exampleSetFlag": true
+        "exampleSetFlag": true
+      },
+      "SpringDefaultHeaders": {
+        "type": "object",
+        "properties": {
+          "__TypeId__": {
+            "type": "string",
+            "description": "Spring Type Id Header",
+            "example": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+            "exampleSetFlag": true,
+            "enum": [
+              "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+              "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
+            ]
+          }
         },
-        "HeadersUnknown": {
-          "type": "object",
-          "properties": {},
-          "example": {},
-          "exampleSetFlag": true
+        "example": {
+          "__TypeId__": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
         },
-        "AnotherPayloadDto": {
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string",
-              "exampleSetFlag": false
-            },
-            "example": {
-              "$ref": "#/components/schemas/ExamplePayloadDto",
-              "exampleSetFlag": false
-            }
-          },
-          "example": {
-            "foo": "string",
-            "example": {
-              "someString": "string",
-              "someLong": 0,
-              "someEnum": "FOO1"
-            }
-          },
-          "exampleSetFlag": true
-        },
-        "SpringDefaultHeaders": {
-          "type": "object",
-          "properties": {
-            "__TypeId__": {
-              "type": "string",
-              "description": "Spring Type Id Header",
-              "example": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-              "exampleSetFlag": true,
-              "enum": [
-                "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-              ]
-            }
-          },
-          "example": {
-            "__TypeId__": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-          },
-          "exampleSetFlag": true
-        }
+        "exampleSetFlag": true
       }
     }
   }


### PR DESCRIPTION
After removing the title from the document on the backend, the UI which expected a map of string -> doc breaks.
I originally added support for multiple documents to enable loading of multiple docs of different services in a standalone app, but it is not in use (and far from being usable), so I decided to remove it for now.