### PR TITLE
fix: Display type of element in array

### DIFF
--- a/src/app/schemas/schema/schema.component.html
+++ b/src/app/schemas/schema/schema.component.html
@@ -6,7 +6,8 @@
       <span class="required" *ngIf="schema.required?.includes(property.key)">*</span>
     </td>
     <td>
-      <span class="type" *ngIf="property.value.type">{{ property.value.type }}</span>
+      <span class="type" *ngIf="property.value.type == 'array'">{{ property.value.items.type }}[]</span>
+      <span class="type" *ngIf="property.value.type != 'array'">{{ property.value.type }}</span>
       <span class="type" *ngIf="property.value.name">
         <a [href]="property.value.anchorUrl">{{ property.value.name }}</a>
       </span>

--- a/src/app/shared/asyncapi-mapper.service.ts
+++ b/src/app/shared/asyncapi-mapper.service.ts
@@ -12,6 +12,7 @@ interface ServerAsyncApiSchema {
   format: string;
   enum: string[];
   properties?: Map<string, ServerAsyncApiSchema>;
+  items?: ServerAsyncApiSchema,
   example?: {
     [key: string]: object;
   };
@@ -174,6 +175,7 @@ export class AsyncApiMapperService {
 
     private mapSchema(schemaName: string, schema: ServerAsyncApiSchema): Schema {
       const properties = schema.properties !== undefined ? this.mapSchemas(schema.properties) : undefined
+      const items = schema.items !== undefined ? this.mapSchema(schema.$ref+"[]", schema.items) : undefined;
       const example = schema.example !== undefined ? new Example(schema.example) : undefined
       return {
         name: schema.$ref,
@@ -181,6 +183,7 @@ export class AsyncApiMapperService {
         anchorIdentifier: '#' + schemaName,
         anchorUrl: AsyncApiMapperService.BASE_URL + schema.$ref?.split('/')?.pop(),
         type: schema.type,
+        items: items,
         format: schema.format,
         enum: schema.enum,
         properties: properties,

--- a/src/app/shared/models/schema.model.ts
+++ b/src/app/shared/models/schema.model.ts
@@ -3,12 +3,18 @@ import { Example } from './example.model';
 export interface Schema {
     name?: string;
     description?: string;
+
     anchorIdentifier?: string;
     anchorUrl?: string;
+
     type?: string;
-    format?: string;
-    enum?: string[];
+    // type == object
     properties?: Map<string, Schema>;
-    example?: Example;
+    // type == array
+    items?: Schema;
+
+    format?: string;
     required?: string[];
+    enum?: string[];
+    example?: Example;
 }


### PR DESCRIPTION
This is a very basic fix to display arrays - when the property is on the first level of the object.

In general, we should start looking for displaying more complex objects at all/better, which contain
- arrays of objects
- nested objects
- other types?
But that is another task outside of the PR.

Closes https://github.com/springwolf/springwolf-ui/issues/31