### PR TITLE
Show object ref for array schema properties

### DIFF
--- a/src/app/schemas/schema/schema.component.html
+++ b/src/app/schemas/schema/schema.component.html
@@ -6,7 +6,12 @@
       <span class="required" *ngIf="schema.required?.includes(property.key)">*</span>
     </td>
     <td>
-      <span class="type" *ngIf="property.value.type == 'array'">{{ property.value.items.type }}[]</span>
+      <ng-container *ngIf="property.value.items">
+        <span class="type" *ngIf="property.value.items.type && !property.value.items.anchorUrl">{{ property.value.items.type }}[]</span>
+        <span class="type" *ngIf="property.value.items.anchorUrl">
+          <a [href]="property.value.items.anchorUrl">{{ property.value.items.name }}[]</a>
+        </span>
+      </ng-container>
       <span class="type" *ngIf="property.value.type != 'array'">{{ property.value.type }}</span>
       <span class="type" *ngIf="property.value.name">
         <a [href]="property.value.anchorUrl">{{ property.value.name }}</a>


### PR DESCRIPTION
We have a schema with an array of other objects inside.
`
"documents": {
            "type": "array",
            "exampleSetFlag": false,
            "items": {
              "$ref": "#/components/schemas/ProductDocumentDto",
              "exampleSetFlag": false
            }
          }
`
Until now this would only be displayed as "array" without link to the related schema. 
This PR adds a href link (like existing before) to the schema definition if there is a $ref inside the items.