### PR TITLE
test: Add cloud-stream mock

### DIFF
--- a/script/update_mock_data.js
+++ b/script/update_mock_data.js
@@ -15,4 +15,5 @@ const downloadFile = (url, path) => {
 }
 
 downloadFile("https://raw.githubusercontent.com/springwolf/springwolf-core/master/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json", "src/app/shared/mock/mock.springwolf-amqp-example.json")
+downloadFile("https://raw.githubusercontent.com/springwolf/springwolf-core/master/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json", "src/app/shared/mock/mock.springwolf-cloud-stream-example.json")
 downloadFile("https://raw.githubusercontent.com/springwolf/springwolf-core/master/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json", "src/app/shared/mock/mock.springwolf-kafka-example.json")

--- a/src/app/shared/mock/mock-server.ts
+++ b/src/app/shared/mock/mock-server.ts
@@ -1,13 +1,8 @@
 import { InMemoryDbService, RequestInfo, STATUS } from 'angular-in-memory-web-api';
 import mockSpringwolfApp from './mock.springwolf-app.json';
 import mockSpringwolfAmqp from './mock.springwolf-amqp-example.json';
+import mockSpringwolfCloudStream from './mock.springwolf-cloud-stream-example.json';
 import mockSpringwolfKafka from './mock.springwolf-kafka-example.json';
-
-const mockAsyncApi = {
-  ...mockSpringwolfApp,
-  ...mockSpringwolfAmqp,
-  ...mockSpringwolfKafka,
-}
 
 export class MockServer implements InMemoryDbService {
   createDb() {
@@ -16,11 +11,13 @@ export class MockServer implements InMemoryDbService {
 
   get(reqInfo: RequestInfo) {
     console.log("Returning mock data")
+
     if (reqInfo.req.url.endsWith('/docs')) {
+      const body = this.selectMockData()
       return reqInfo.utils.createResponse$(() => {
         return {
           status: STATUS.OK,
-          body: mockSpringwolfKafka
+          body: body
         }
       });
     }
@@ -40,4 +37,17 @@ export class MockServer implements InMemoryDbService {
     return undefined;
   }
 
+  private selectMockData() {
+    const hostname = window.location.hostname;
+
+    if(hostname.includes("app")) {
+      return mockSpringwolfApp;
+    } else if(hostname.includes("amqp")) {
+      return mockSpringwolfAmqp;
+    } else if(hostname.includes("cloud-stream")) {
+      return mockSpringwolfCloudStream;
+    }
+    // Kafka is default
+    return mockSpringwolfKafka;
+  }
 }

--- a/src/app/shared/mock/mock.springwolf-cloud-stream-example.json
+++ b/src/app/shared/mock/mock.springwolf-cloud-stream-example.json
@@ -1,0 +1,200 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Springwolf example project - CloudStream",
+    "version": "1.0.0",
+    "description": "Springwolf example project",
+    "contact": {
+      "name": "springwolf",
+      "url": "https://github.com/springwolf/springwolf-core",
+      "email": "example@example.com"
+    },
+    "license": {
+      "name": "Apache License 2.0"
+    }
+  },
+  "servers": {
+    "kafka": {
+      "url": "kafka:29092",
+      "protocol": "kafka"
+    }
+  },
+  "channels": {
+    "consumer-method-input-topic": {
+      "publish": {
+        "operationId": "consumer-method-input-topic_publish_consumerMethod",
+        "description": "Auto-generated description",
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
+          "name": "io.github.stavshamir.springwolf.example.payload.ConsumerPayload",
+          "title": "ConsumerPayload",
+          "payload": {
+            "$ref": "#/components/schemas/ConsumerPayload"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "kafka": {}
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "input-topic": {
+      "publish": {
+        "operationId": "input-topic_publish_process",
+        "description": "Auto-generated description",
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
+          "name": "io.github.stavshamir.springwolf.example.payload.InputPayload",
+          "title": "InputPayload",
+          "payload": {
+            "$ref": "#/components/schemas/InputPayload"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "kafka": {}
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    },
+    "output-topic": {
+      "subscribe": {
+        "operationId": "output-topic_subscribe_process",
+        "description": "Auto-generated description",
+        "bindings": {
+          "kafka": {}
+        },
+        "message": {
+          "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
+          "name": "io.github.stavshamir.springwolf.example.payload.OutputPayload",
+          "title": "OutputPayload",
+          "payload": {
+            "$ref": "#/components/schemas/OutputPayload"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "kafka": {}
+          }
+        }
+      },
+      "bindings": {
+        "kafka": {}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ConsumerPayload": {
+        "type": "object",
+        "properties": {
+          "payloadString": {
+            "type": "string",
+            "exampleSetFlag": false,
+            "types": [
+              "string"
+            ]
+          }
+        },
+        "example": {
+          "payloadString": "string"
+        },
+        "exampleSetFlag": true
+      },
+      "HeadersNotDocumented": {
+        "type": "object",
+        "properties": {},
+        "example": {},
+        "exampleSetFlag": true,
+        "types": [
+          "object"
+        ]
+      },
+      "InputPayload": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "array",
+            "exampleSetFlag": false,
+            "items": {
+              "type": "string",
+              "exampleSetFlag": false,
+              "types": [
+                "string"
+              ]
+            },
+            "types": [
+              "array"
+            ]
+          },
+          "bar": {
+            "type": "integer",
+            "format": "int32",
+            "exampleSetFlag": false,
+            "types": [
+              "integer"
+            ]
+          }
+        },
+        "description": "Input payload model",
+        "example": {
+          "foo": [
+            "string"
+          ],
+          "bar": 0
+        },
+        "exampleSetFlag": true
+      },
+      "OutputPayload": {
+        "required": [
+          "someString"
+        ],
+        "type": "object",
+        "properties": {
+          "someString": {
+            "type": "string",
+            "description": "Some string field",
+            "example": "some string value",
+            "exampleSetFlag": true,
+            "types": [
+              "string"
+            ]
+          },
+          "someLong": {
+            "type": "integer",
+            "description": "Some long field",
+            "format": "int64",
+            "example": 5,
+            "exampleSetFlag": true,
+            "types": [
+              "integer"
+            ]
+          }
+        },
+        "description": "Output payload model",
+        "example": {
+          "someString": "some string value",
+          "someLong": 5
+        },
+        "exampleSetFlag": true
+      }
+    }
+  },
+  "tags": []
+}


### PR DESCRIPTION
This also includes a hostname check for the mock server, so that i.e. amqp.demo.springwolf.dev will serve the amqp mock data. Same for kafka (default), app and cloud-stream.demo.springwolf.dev